### PR TITLE
Update/requests

### DIFF
--- a/quick.go
+++ b/quick.go
@@ -21,8 +21,9 @@ type Ctx struct {
 	Params   map[string]string
 	Query    map[string]string
 	// JSON     map[string]interface{}
-	BodyByte []byte
-	JsonStr  string
+	resStatus int
+	BodyByte  []byte
+	JsonStr   string
 }
 
 type Route struct {
@@ -458,8 +459,7 @@ func (c *Ctx) JSON(v interface{}) error {
 		return err
 	}
 	c.Response.Header().Set("Content-Type", "application/json")
-	_, err = c.Response.Write(b)
-	return err
+	return c.writeResponse(b)
 }
 
 func (c *Ctx) XML(v interface{}) error {
@@ -468,13 +468,17 @@ func (c *Ctx) XML(v interface{}) error {
 		return err
 	}
 	c.Response.Header().Set("Content-Type", "text/xml")
-	_, err = c.Response.Write(b)
+	return c.writeResponse(b)
+}
+
+func (c *Ctx) writeResponse(b []byte) error {
+	c.Response.WriteHeader(c.resStatus)
+	_, err := c.Response.Write(b)
 	return err
 }
 
 func (c *Ctx) Byte(b []byte) (err error) {
-	_, err = c.Response.Write(b)
-	return err
+	return c.writeResponse(b)
 }
 
 func (c *Ctx) SendString(s string) error {
@@ -502,7 +506,7 @@ func (c *Ctx) Accepts(acceptType string) *Ctx {
 }
 
 func (c *Ctx) Status(status int) *Ctx {
-	c.Response.WriteHeader(status)
+	c.resStatus = status
 	return c
 }
 

--- a/quick_test.go
+++ b/quick_test.go
@@ -3,7 +3,6 @@ package quick
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"reflect"
@@ -165,7 +164,7 @@ func TestQuick_Post(t *testing.T) {
 
 	testSuccessMockHandler := func(c *Ctx) {
 		c.Set("Content-Type", "application/json")
-		b, _ := io.ReadAll(c.Request.Body)
+		b := c.BodyBytes()
 		resp := concat.String(`"data":`, string(b))
 		c.Status(200)
 		c.SendString(resp)
@@ -186,7 +185,7 @@ func TestQuick_Post(t *testing.T) {
 	testSuccessMockHandlerBind := func(c *Ctx) {
 		c.Set("Content-Type", "application/json")
 		mt := new(myType)
-		if err := c.Bind(mt); err != nil {
+		if err := c.Bind(&mt); err != nil {
 			t.Errorf("error: %v", err)
 		}
 		b, _ := json.Marshal(mt)
@@ -288,7 +287,7 @@ func TestQuick_Put(t *testing.T) {
 
 	testSuccessMockHandler := func(c *Ctx) {
 		c.Set("Content-Type", "application/json")
-		b, _ := io.ReadAll(c.Request.Body)
+		b := c.BodyBytes()
 		resp := concat.String(`"data":`, string(b))
 		c.Byte([]byte(resp))
 	}
@@ -415,7 +414,7 @@ func TestCtx_Param(t *testing.T) {
 				Params:   tt.fields.Params,
 				Query:    tt.fields.Query,
 				//JSON:     tt.fields.JSON,
-				BodyByte: tt.fields.BodyByte,
+				bodyByte: tt.fields.BodyByte,
 				JsonStr:  tt.fields.JsonStr,
 			}
 			if got := c.Param(tt.args.key); got != tt.want {
@@ -456,7 +455,7 @@ func TestCtx_Body(t *testing.T) {
 				Params:   tt.fields.Params,
 				Query:    tt.fields.Query,
 				//JSON:     tt.fields.JSON,
-				BodyByte: tt.fields.BodyByte,
+				bodyByte: tt.fields.BodyByte,
 				JsonStr:  tt.fields.JsonStr,
 			}
 			if err := c.Body(tt.args.v); (err != nil) != tt.wantErr {
@@ -493,7 +492,7 @@ func TestCtx_BodyString(t *testing.T) {
 				Params:   tt.fields.Params,
 				Query:    tt.fields.Query,
 				//JSON:     tt.fields.JSON,
-				BodyByte: tt.fields.BodyByte,
+				bodyByte: tt.fields.BodyByte,
 				JsonStr:  tt.fields.JsonStr,
 			}
 			if got := c.BodyString(); got != tt.want {
@@ -619,7 +618,7 @@ func TestCtx_Json(t *testing.T) {
 				Params:   tt.fields.Params,
 				Query:    tt.fields.Query,
 				//JSON:     tt.fields.JSON,
-				BodyByte: tt.fields.BodyByte,
+				bodyByte: tt.fields.BodyByte,
 				JsonStr:  tt.fields.JsonStr,
 			}
 			if err := c.JSON(tt.args.v); (err != nil) != tt.wantErr {
@@ -660,7 +659,7 @@ func TestCtx_Byte(t *testing.T) {
 				Params:   tt.fields.Params,
 				Query:    tt.fields.Query,
 				//JSON:     tt.fields.JSON,
-				BodyByte: tt.fields.BodyByte,
+				bodyByte: tt.fields.BodyByte,
 				JsonStr:  tt.fields.JsonStr,
 			}
 			if err := c.Byte(tt.args.b); (err != nil) != tt.wantErr {
@@ -701,7 +700,7 @@ func TestCtx_SendString(t *testing.T) {
 				Params:   tt.fields.Params,
 				Query:    tt.fields.Query,
 				//JSON:     tt.fields.JSON,
-				BodyByte: tt.fields.BodyByte,
+				bodyByte: tt.fields.BodyByte,
 				JsonStr:  tt.fields.JsonStr,
 			}
 			if err := c.SendString(tt.args.s); (err != nil) != tt.wantErr {
@@ -742,7 +741,7 @@ func TestCtx_Set(t *testing.T) {
 				Params:   tt.fields.Params,
 				Query:    tt.fields.Query,
 				//JSON:     tt.fields.JSON,
-				BodyByte: tt.fields.BodyByte,
+				bodyByte: tt.fields.BodyByte,
 				JsonStr:  tt.fields.JsonStr,
 			}
 			c.Set(tt.args.key, tt.args.value)
@@ -781,7 +780,7 @@ func TestCtx_Accepts(t *testing.T) {
 				Params:   tt.fields.Params,
 				Query:    tt.fields.Query,
 				//JSON:     tt.fields.JSON,
-				BodyByte: tt.fields.BodyByte,
+				bodyByte: tt.fields.BodyByte,
 				JsonStr:  tt.fields.JsonStr,
 			}
 			if got := c.Accepts(tt.args.acceptType); !reflect.DeepEqual(got, tt.want) {
@@ -822,7 +821,7 @@ func TestCtx_Status(t *testing.T) {
 				Params:   tt.fields.Params,
 				Query:    tt.fields.Query,
 				//JSON:     tt.fields.JSON,
-				BodyByte: tt.fields.BodyByte,
+				bodyByte: tt.fields.BodyByte,
 				JsonStr:  tt.fields.JsonStr,
 			}
 			if got := c.Status(tt.args.status); !reflect.DeepEqual(got, tt.want) {


### PR DESCRIPTION
## Atualizações no Body, Bind e Response

 - Passou-se a usar a variável interna `bodyByte` para armazenar as bytes do body de entrada
 - Criou-se a função `BodyBytes` para recuperar os bytes do body de entrada
 - Criou-se a função `writeResponse` para enviar a resposta final ao cliente, resolvendo o problema de escrever o status code antes dos headers de saída.